### PR TITLE
[chore] git에 추가할 필요 없는 pwa 파일 .gitignore에 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,13 @@ yarn-error.log*
 next-env.d.ts
 
 # pwa
-public/sw.js
-public/workbox-*.js
+**/public/precache.*.*.js
+**/public/sw.js
+**/public/workbox-*.js
+**/public/worker-*.js
+**/public/fallback-*.js
+**/public/precache.*.*.js.map
+**/public/sw.js.map
+**/public/workbox-*.js.map
+**/public/worker-*.js.map
+**/public/fallback-*.js


### PR DESCRIPTION
매번 public에 생기는 pwa 파일들 .gitignore에 추가해도 되는거였더라구여 next-pwa있는 레포에서도 추가해둔 상황이었습니당

https://github.com/shadowwalker/next-pwa/issues/110
https://github.com/shadowwalker/next-pwa/blob/master/.gitignore