### PR TITLE
[refactor] 회원가입 패스워드 페이지 코드 정리 

### DIFF
--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import BasicLayout from '@/components/layout/BasicLayout';
 import Email from './email/components/Email';
-import Password from './components/Password';
+import Password from './password/components/Password';
 import TermsOfService from './terms-of-service/components/TermsOfService';
 import SetupNickname from './components/SetupNickname';
 import { useMutation } from '@apollo/client';

--- a/src/app/signup/password/components/Password.tsx
+++ b/src/app/signup/password/components/Password.tsx
@@ -1,0 +1,35 @@
+import { Registration } from '../../page';
+import PasswordForm from './PasswordForm';
+
+const Password = ({
+  registration,
+  handleRegistration,
+  moveNextStep,
+}: {
+  registration: Registration;
+  handleRegistration: (password: (registration: Registration) => Partial<Registration>) => void;
+  moveNextStep: () => void;
+}) => {
+  return (
+    <div className="flex flex-col h-full">
+      <Description />
+      <PasswordForm
+        registration={registration}
+        handleRegistration={handleRegistration}
+        moveNextStep={moveNextStep}
+      />
+    </div>
+  );
+};
+
+export default Password;
+
+const Description = () => {
+  return (
+    <p className="font-semibold text-2xl">
+      비밀번호를
+      <br />
+      입력해주세요.
+    </p>
+  );
+};

--- a/src/app/signup/password/components/PasswordForm.tsx
+++ b/src/app/signup/password/components/PasswordForm.tsx
@@ -1,10 +1,11 @@
+import { useState } from 'react';
 import Button from '@/components/common/Button';
 import Input from '@/components/common/Input';
-import { Registration } from '../page';
 import { Eye, EyeOff } from '@/components/common/icons';
-import { useState } from 'react';
+import { Registration } from '../../page';
+import usePasswordFormViewModel from '../hooks/usePasswordFormViewModel';
 
-const Password = ({
+const PasswordForm = ({
   registration,
   handleRegistration,
   moveNextStep,
@@ -13,58 +14,27 @@ const Password = ({
   handleRegistration: (password: (registration: Registration) => Partial<Registration>) => void;
   moveNextStep: () => void;
 }) => {
-  const handleInputChange = (
-    e: React.ChangeEvent<HTMLInputElement>,
-    validate: (value: string) => { error: boolean; invalidType: boolean; invalidLength: boolean },
-  ) => {
-    const { id, value } = e.target;
-    const error = validate(value);
-
-    if (id === 'password') {
-      handleRegistration((prev) => ({
-        [id]: { ...prev[id], value, ...error },
-      }));
-    }
-  };
-
-  const handleCTAButton = () => {
-    moveNextStep();
-  };
-
-  const isValidInput = !!(registration.password.value && !registration.password.error);
+  const { isValidInput, handleInputChange, handleSubmit } = usePasswordFormViewModel({
+    registration,
+    handleRegistration,
+    moveNextStep,
+  });
 
   return (
-    <div className="grid h-full">
-      <div>
-        <Description />
-        <div className="grid items-end">
-          <form className="grid gap-y-8 pt-[88px]">
-            <PasswordInput
-              registration={registration}
-              isValidInput={isValidInput}
-              handleInputChange={handleInputChange}
-            />
-          </form>
-        </div>
-      </div>
-      <Button onClick={handleCTAButton} disabled={!isValidInput} className="self-end">
+    <form onSubmit={handleSubmit} className="flex flex-col flex-1 justify-between pt-[88px]">
+      <PasswordInput
+        registration={registration}
+        isValidInput={isValidInput}
+        handleInputChange={handleInputChange}
+      />
+      <Button type="submit" disabled={!isValidInput}>
         다음
       </Button>
-    </div>
+    </form>
   );
 };
 
-export default Password;
-
-const Description = () => {
-  return (
-    <p className="font-semibold text-2xl">
-      비밀번호를
-      <br />
-      입력해주세요.
-    </p>
-  );
-};
+export default PasswordForm;
 
 const PasswordInput = ({
   registration,
@@ -73,34 +43,12 @@ const PasswordInput = ({
 }: {
   registration: Registration;
   isValidInput: boolean;
-  handleInputChange: (
-    e: React.ChangeEvent<HTMLInputElement>,
-    validate: (value: string) => { error: boolean; invalidType: boolean; invalidLength: boolean },
-  ) => void;
+  handleInputChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }) => {
   const [masking, setMasking] = useState(true);
 
   const toggleMasking = () => {
     setMasking((prev) => !prev);
-  };
-
-  const validate = (value: string) => {
-    if (value === '') {
-      return { error: false, invalidType: false, invalidLength: false };
-    }
-
-    const isAlphabet = /[a-zA-Z]/.test(value);
-    const isNumber = /\d/.test(value);
-    const isSpecialCharacter = /[!@#$%^&*()_+{}\[\]:;<>,.?~\\/-]/.test(value);
-
-    const isValidType = [isAlphabet, isNumber, isSpecialCharacter].filter(Boolean).length >= 2;
-    const isValidLength = /^(.{8,30})$/.test(value);
-
-    return {
-      error: !isValidType || !isValidLength,
-      invalidType: !isValidType,
-      invalidLength: !isValidLength,
-    };
   };
 
   return (
@@ -127,7 +75,7 @@ const PasswordInput = ({
             </p>
           )
         }
-        onChange={(e) => handleInputChange(e, validate)}
+        onChange={handleInputChange}
       />
     </label>
   );

--- a/src/app/signup/password/hooks/usePasswordFormViewModel.ts
+++ b/src/app/signup/password/hooks/usePasswordFormViewModel.ts
@@ -1,0 +1,56 @@
+import { Registration } from '../../page';
+
+const useInput = ({
+  registration,
+  handleRegistration,
+  moveNextStep,
+}: {
+  registration: Registration;
+  handleRegistration: (password: (registration: Registration) => Partial<Registration>) => void;
+  moveNextStep: () => void;
+}) => {
+  const validate = (value: string) => {
+    if (value === '') {
+      return { error: false, invalidType: false, invalidLength: false };
+    }
+
+    const isAlphabet = /[a-zA-Z]/.test(value);
+    const isNumber = /\d/.test(value);
+    const isSpecialCharacter = /[!@#$%^&*()_+{}\[\]:;<>,.?~\\/-]/.test(value);
+
+    const isValidType = [isAlphabet, isNumber, isSpecialCharacter].filter(Boolean).length >= 2;
+    const isValidLength = /^(.{8,30})$/.test(value);
+
+    return {
+      error: !isValidType || !isValidLength,
+      invalidType: !isValidType,
+      invalidLength: !isValidLength,
+    };
+  };
+
+  const isValidInput = !!(registration.password.value && !registration.password.error);
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { id, value } = e.target;
+    const error = validate(value);
+
+    if (id === 'password') {
+      handleRegistration((prev) => ({
+        [id]: { ...prev[id], value, ...error },
+      }));
+    }
+  };
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    moveNextStep();
+  };
+
+  return {
+    isValidInput,
+    handleInputChange,
+    handleSubmit,
+  };
+};
+
+export default useInput;


### PR DESCRIPTION

## 구현한 것


- 컴포넌트 분리
  - 폼과 커스텀 훅을 분리, 커스텀 훅은 현재 훅을 사용하고 있지 않지만 이후 회원가입 페이지 상위에서 컨텍스트로 상태를 관리하는 경우 추가될 예정
  
- 레이아웃 마이페이지 방식과 통일

- 버튼 클릭이 아니라 submit으로 변경 

https://github.com/jirum-alarm/jirum-alarm-frontend/assets/50096419/2ad889e6-a936-40a5-8090-2a41e90103bb

