### PR TITLE
[fix] 회원가입 패스워드 입력 헬퍼 텍스트 패딩 조정

### DIFF
--- a/src/app/signup/password/components/PasswordForm.tsx
+++ b/src/app/signup/password/components/PasswordForm.tsx
@@ -97,7 +97,7 @@ const HelperText = ({
   isInvalidLength: boolean;
 }) => {
   return (
-    <ul className="list-disc pl-8 pt-2">
+    <ul className="list-disc pl-4 pt-2">
       <li
         className={cn(
           'transition-colors',


### PR DESCRIPTION
## 구현한 것
헬퍼 텍스트의 패딩이 너무 커서 조금 조정했슴다.

## 동작 확인
![스크린샷 2024-01-16 오후 12 08 40](https://github.com/jirum-alarm/jirum-alarm-frontend/assets/50096419/f89c5c1a-c373-4fad-a7e4-36e98abaa723)
