### PR TITLE
[fix] 카테고리 수정시 이전 데이터 체크

### DIFF
--- a/src/app/mypage/categories/components/CategoriesForm.tsx
+++ b/src/app/mypage/categories/components/CategoriesForm.tsx
@@ -9,7 +9,7 @@ const CategoriesForm = () => {
   return (
     <form className="flex flex-1 flex-col justify-between" onSubmit={handleSubmit}>
       <CategoriesCheckboxGroup categories={categories} handleCheckChange={handleCheckChange} />
-      <Button type="submit" disabled={!canSubmit}>
+      <Button type="submit" disabled={!canSubmit()}>
         저장
       </Button>
     </form>

--- a/src/util/object.ts
+++ b/src/util/object.ts
@@ -1,10 +1,10 @@
-export function shallowEqual(objA: Record<string, any>, objB: Record<string, any>): boolean {
+export const shallowEqual = <T>(objA: T, objB: T): boolean => {
   if (Object.is(objA, objB)) return true;
   if (typeof objA !== 'object' || objA === null || typeof objB !== 'object' || objB === null) {
     return false;
   }
-  const keysA = Object.keys(objA);
-  const keysB = Object.keys(objB);
+  const keysA = Object.keys(objA) as Array<keyof T>;
+  const keysB = Object.keys(objB) as Array<keyof T>;
   if (keysA.length !== keysB.length) {
     return false;
   }
@@ -14,4 +14,16 @@ export function shallowEqual(objA: Record<string, any>, objB: Record<string, any
     }
   }
   return true;
-}
+};
+
+export const shallowArrayEqual = <T>(arrA: T[], arrB: T[]): boolean => {
+  if (!arrA || !arrB || arrA.length !== arrB.length) return false;
+
+  for (let i = 0; i < arrA.length; i++) {
+    if (!shallowEqual(arrA[i], arrB[i])) {
+      return false;
+    }
+  }
+
+  return true;
+};


### PR DESCRIPTION
<!-- 모든 섹션은 꼭 다 채우지 않아도 됩니다! -->

## 구현한 것
- util함수인 `shallowArrayEqual` 추가 및 타입정의 코드 추가
- 이전 카테고리와 현재 선택된 카테고리가 변경이 있는지 체크하는 로직 추가

<!-- PR에서 구현하여 확인해주었으면 하는 것을 적어주세요 -->

## 동작 확인

https://github.com/jirum-alarm/jirum-alarm-frontend/assets/89559826/4199a3b1-8b3a-4c03-9516-623535e1c062


<!-- PR의 동작을 확인할 수 있는 스크린샷이나 영상 혹은 방법을 추가해주세요 -->
