### PR TITLE
[style] ios 사파리에서 input창이 둥글게 보이는 현상 수정

### DIFF
--- a/src/components/common/Input/variant/input.ts
+++ b/src/components/common/Input/variant/input.ts
@@ -40,7 +40,7 @@ export const inputVariant = cva(
   {
     variants: {
       variant: {
-        standard: ['border-b', 'placeholder:text-gray-400'],
+        standard: ['border-b', 'placeholder:text-gray-400', 'rounded-none'],
       },
       size: {
         md: ['text-base', 'px-2', 'py-3'],


### PR DESCRIPTION
## 구현한 것
- input rounded 수정

## 동작 확인

### 변경 전
<img width="405" alt="스크린샷 2024-01-27 오후 7 44 53" src="https://github.com/jirum-alarm/jirum-alarm-frontend/assets/89559826/1149ef83-342c-4b7a-9ef1-9833a7b76698">

### 변경 후
<img width="403" alt="스크린샷 2024-01-27 오후 7 44 43" src="https://github.com/jirum-alarm/jirum-alarm-frontend/assets/89559826/11796aa0-74c8-420e-b679-8fd7d1ca9392">

<!-- PR의 동작을 확인할 수 있는 스크린샷이나 영상 혹은 방법을 추가해주세요 -->
