### PR TITLE
[fix] Input컴포넌트 helperText 변경

### DIFF
--- a/src/app/login/email/components/EmailLoginForm.tsx
+++ b/src/app/login/email/components/EmailLoginForm.tsx
@@ -49,7 +49,8 @@ const EmailInput = ({
         required
         value={email.value}
         icon={email.focus ? <Cancel onMouseDown={email.reset} /> : ''}
-        error={email.error && '올바른 이메일 형식으로 입력해주세요.'}
+        error={email.error}
+        helperText={email.error && '올바른 이메일 형식으로 입력해주세요.'}
         onChange={email.handleInputChange}
         onFocus={email.handleInputFocus}
         onBlur={email.handleInputBlur}

--- a/src/app/mypage/account/nickname/components/NickNameForm.tsx
+++ b/src/app/mypage/account/nickname/components/NickNameForm.tsx
@@ -23,7 +23,7 @@ const NickNameForm = () => {
             </button>
           )
         }
-        error={nickname.error && '공백없이 2~12자로 입력해주세요.'}
+        error={nickname.error}
         helperText="공백없이 2~12자로 입력해주세요."
       />
       <Button type="submit" disabled={!isValidInput}>

--- a/src/app/mypage/keyword/components/KeywordInput.tsx
+++ b/src/app/mypage/keyword/components/KeywordInput.tsx
@@ -12,7 +12,8 @@ const KeywordInput = () => {
         autoFocus
         type="text"
         placeholder="키워드를 입력해주세요."
-        error={keyword.error && '키워드는 최대 20자까지만 입력할 수 있어요.'}
+        error={keyword.error}
+        helperText={'키워드는 최대 20자까지만 입력할 수 있어요.'}
         value={keyword.value}
         onChange={handleInputChange}
         icon={

--- a/src/app/signup/email/components/EmailForm.tsx
+++ b/src/app/signup/email/components/EmailForm.tsx
@@ -70,7 +70,8 @@ const EmailInput = ({
         required
         value={registration.email.value}
         icon={registration.email.focus ? <Cancel onMouseDown={reset} /> : ''}
-        error={registration.email.error && '올바른 이메일 형식으로 입력해주세요.'}
+        error={registration.email.error}
+        helperText={registration.email.error && '올바른 이메일 형식으로 입력해주세요.'}
         onChange={handleInputChange}
         onFocus={handleInputFocus}
         onBlur={handleInputBlur}

--- a/src/app/signup/nickname/components/NicknameForm.tsx
+++ b/src/app/signup/nickname/components/NicknameForm.tsx
@@ -67,7 +67,8 @@ const NicknameInput = ({
       placeholder="닉네임을 입력해주세요."
       value={registration.nickname.value}
       icon={registration.nickname.focus ? <Cancel id="cancel" onMouseDown={reset} /> : ''}
-      error={registration.nickname.error && '공백없이 2~12자로 입력해주세요.'}
+      error={registration.nickname.error}
+      helperText={registration.nickname.error && '공백없이 2~12자로 입력해주세요.'}
       onChange={handleInputChange}
       onFocus={handleInputFocus}
       onBlur={handleInputBlur}

--- a/src/components/common/Input/Input.stories.tsx
+++ b/src/components/common/Input/Input.stories.tsx
@@ -25,8 +25,8 @@ export const Placeholder: Story = {
 };
 export const Error: Story = {
   args: {
-    error: '올바른 이메일 주소를 입력해주세요',
-    helperText: '공백없이 2~12자로 입력해주세요.',
+    error: true,
+    helperText: '올바른 이메일 주소를 입력해주세요',
     value: 'useremail |',
   },
 };

--- a/src/components/common/Input/Input.tsx
+++ b/src/components/common/Input/Input.tsx
@@ -15,7 +15,7 @@ interface InputProps
   variant?: 'standard';
   size?: 'md';
   helperText?: string | React.ReactNode;
-  error?: string | boolean | React.ReactNode;
+  error?: boolean;
   color?: 'black';
   icon?: React.ReactNode;
 }
@@ -43,8 +43,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
             className={cn(inputVariant({ variant, size, color }), icon && 'pr-10')}
           />
         </div>
-        {!error && helperText && <div className={helperVariant({ size })}>{helperText}</div>}
-        {error && <div className={errorVariant({ size, error: !!error })}>{error}</div>}
+        {helperText && <div className={helperVariant({ size, error })}>{helperText}</div>}
       </div>
     );
   },

--- a/src/components/common/Input/variant/input.ts
+++ b/src/components/common/Input/variant/input.ts
@@ -63,9 +63,6 @@ export const errorVariant = cva('', {
     size: {
       md: ['pt-2', 'text-xs'],
     },
-    error: {
-      true: ['text-error-500'],
-    },
   },
   defaultVariants: {
     size: 'md',
@@ -75,7 +72,11 @@ export const errorVariant = cva('', {
 export const helperVariant = cva('', {
   variants: {
     size: {
-      md: ['pt-2', 'text-xs', 'text-gray-400'],
+      md: ['pt-2', 'text-xs'],
+    },
+    error: {
+      true: ['text-error-500'],
+      false: ['text-gray-400'],
     },
   },
   defaultVariants: {


### PR DESCRIPTION
<!-- 모든 섹션은 꼭 다 채우지 않아도 됩니다! -->

## 구현한 것
- error props의 유무에 따라 helperText의 색상이 변경되도록 변경
- error props는 무조건 bool값만 받을 수 있게 수정

## 구현하지 않은 것

<!-- PR에서 구현하지 않아 확인하지 않아도 되는 것을 적어주세요 -->

## 동작 확인
아래와 같은 느낌으로 사용하게끔 변경했습니다
```tsx
<Input
  type="email"
  value={email.value}
  icon={email.focus ? <Cancel onMouseDown={email.reset} /> : ''}
  error={email.error}
  helperText={email.error && '올바른 이메일 형식으로 입력해주세요.'}
  onChange={email.handleInputChange}
/>
```

<!-- PR의 동작을 확인할 수 있는 스크린샷이나 영상 혹은 방법을 추가해주세요 -->
