### PR TITLE
[fix] 홈 화면 스와이프 안되는 문제 해결

### DIFF
--- a/src/app/(home)/components/ProductCard.tsx
+++ b/src/app/(home)/components/ProductCard.tsx
@@ -19,7 +19,7 @@ export const ProductCard = (props: IProductCard) => {
             <h4>{product.category}</h4>
           </div>
           <div className="flex justify-between">
-            <h3 className="my-2 pl-4 pr-2">{product.title}</h3>
+            <h3 className="my-2 break-all pl-4 pr-2">{product.title}</h3>
             <h4 className="my-2 whitespace-nowrap pl-2 pr-4 text-xs">{timestamp}</h4>
           </div>
         </div>


### PR DESCRIPTION
resolve #163

<!-- 모든 섹션은 꼭 다 채우지 않아도 됩니다! -->


문제: 스와이핑이 안되는 문제 발생

원인:  특정 제품명이 긴 경우 카드 사이즈를 넘쳐서 스와이핑이 되지 않는 문제 발생
![스크린샷 2024-02-29 오전 12 18 27](https://github.com/jirum-alarm/jirum-alarm-frontend/assets/50096419/97eef24b-11f4-4b50-b133-d7d3c91dd8db)

## 구현한 것

<!-- PR에서 구현하여 확인해주었으면 하는 것을 적어주세요 -->
word-break 추가

## 구현하지 않은 것

<!-- PR에서 구현하지 않아 확인하지 않아도 되는 것을 적어주세요 -->

## 동작 확인

![스크린샷 2024-02-29 오전 12 40 02](https://github.com/jirum-alarm/jirum-alarm-frontend/assets/50096419/ce589ecd-b8ee-4a23-8370-f7fd3f022a9d)

