### PR TITLE
[fix] 홈 화면 카테고리 변경시에 새로고침 되는 문제 수정

### DIFF
--- a/src/app/(home)/hooks/useProductListViewModel.ts
+++ b/src/app/(home)/hooks/useProductListViewModel.ts
@@ -4,7 +4,7 @@ import { IProductOutput } from '@/graphql/interface/product';
 import { ICategoryOutput } from '@/graphql/interface/category';
 import { useDevice } from '@/hooks/useDevice';
 import { useQuery, useSuspenseQuery } from '@apollo/client';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 
@@ -12,7 +12,6 @@ const limit = 20;
 const allCategory = { id: 0, name: '전체' };
 
 export const useProductListViewModel = () => {
-  const router = useRouter();
   const searchParams = useSearchParams();
 
   const [hasNextData, setHasNextData] = useState(true);
@@ -51,7 +50,7 @@ export const useProductListViewModel = () => {
       current.delete('categoryId');
     }
     const search = current.toString();
-    router.push(`/?${search}`);
+    history.pushState({}, '', '?' + search);
   };
 
   const fetchMoreProducts = () => {


### PR DESCRIPTION
resolve #167

<!-- 모든 섹션은 꼭 다 채우지 않아도 됩니다! -->

## 구현한 것

useRouter의 router.push 사용시 서치파람 변경 시 페이자가 새로고침 되는 이슈가 있어 history.pushState로 변경

## 구현하지 않은 것

<!-- PR에서 구현하지 않아 확인하지 않아도 되는 것을 적어주세요 -->

## 동작 확인

https://jirum-alarm-frontend-l1pk6vzxm-jirumalarms-projects.vercel.app

<!-- PR의 동작을 확인할 수 있는 스크린샷이나 영상 혹은 방법을 추가해주세요 -->


https://github.com/jirum-alarm/jirum-alarm-frontend/assets/50096419/6b8dac25-03bb-45c6-afee-3868ea38c95a


