### PR TITLE
[fix] 홈 화면 중복되는 아이템 불러오는 문제 개선

### DIFF
--- a/src/app/(home)/hooks/useProductListViewModel.ts
+++ b/src/app/(home)/hooks/useProductListViewModel.ts
@@ -36,7 +36,7 @@ export const useProductListViewModel = () => {
 
   const { ref } = useInView({
     onChange(inView) {
-      if (inView && hasNextData) {
+      if (inView && products && hasNextData) {
         fetchMoreProducts();
       }
     },


### PR DESCRIPTION
<!-- 모든 섹션은 꼭 다 채우지 않아도 됩니다! -->

## 구현한 것
홈 화면에서 첫 20개의 아이템과 같은 아이템 20개를 불러오는 문제가 발생하여, 20개를 불러온 것을 확인한 후에 추가 20개를 불러오도록 변경

<!-- PR에서 구현하여 확인해주었으면 하는 것을 적어주세요 -->

## 구현하지 않은 것

<!-- PR에서 구현하지 않아 확인하지 않아도 되는 것을 적어주세요 -->

## 동작 확인

<!-- PR의 동작을 확인할 수 있는 스크린샷이나 영상 혹은 방법을 추가해주세요 -->


- 첫 로딩에 사용한 20개으의 아이템 외에 새로운 20가의 아이템을 불러오고 있음


https://github.com/jirum-alarm/jirum-alarm-frontend/assets/50096419/d299db76-c8af-4182-9930-6169c507d0e9



