### PR TITLE
[fix] 홈 화면 플러터 웹뷰에서 상단 패딩 조정

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -8,6 +8,7 @@ import { useQuery } from '@apollo/client';
 import { IS_VERCEL_PRD } from '@/constants/env';
 import { QueryUnreadNotificationsCount } from '@/graphql/notification';
 import { UnreadNotificationsCount } from '@/graphql/interface';
+import { isIOSFlutterWeb } from '@/util/ua';
 
 const LOGIN_PATH = '/login';
 const MYPAGE_PATH = '/mypage';
@@ -20,9 +21,11 @@ export default function NavBar() {
     { skip: IS_VERCEL_PRD || !data?.me },
   );
 
+  const layoutPaddingTop = isIOSFlutterWeb() ? 'pt-4' : 'pt-8';
+
   return (
     <>
-      <div className="pt-8">
+      <div className={`${layoutPaddingTop}`}>
         <div className="flex items-center justify-between">
           <Link href="/">
             <div className="grid grid-flow-col items-center gap-x-3">

--- a/src/hooks/useDevice.ts
+++ b/src/hooks/useDevice.ts
@@ -6,7 +6,7 @@ export const useDevice = () => {
   useEffect(() => {
     const userAgent = window.navigator.userAgent;
     const isMobileDevice = Boolean(
-      userAgent.match(/Android|BlackBerry|iPhone|iPad|iPod|Opera Mini|IEMobile|WPDesktop/i),
+      userAgent.match(/Android|BlackBerry|iPhone|iPad|iPod|Opera Mini|IEMobile|WPDesktop|Mobile/i),
     );
     setIsMobile(isMobileDevice);
   }, []);

--- a/src/util/ua.ts
+++ b/src/util/ua.ts
@@ -1,0 +1,6 @@
+export function isIOSFlutterWeb() {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
+  return navigator.userAgent.includes('IOS jirum_alarm_flutter');
+}


### PR DESCRIPTION
resolve #183

<!-- 모든 섹션은 꼭 다 채우지 않아도 됩니다! -->

## 구현한 것

<!-- PR에서 구현하여 확인해주었으면 하는 것을 적어주세요 -->

웹뷰에서 ios의 safeArea 처리를 해서 상단에 패딩이 넓어보여 flutter ios 웹뷰의 경우 상단 패딩조정을 하고 있슴다.

## 구현하지 않은 것

<!-- PR에서 구현하지 않아 확인하지 않아도 되는 것을 적어주세요 -->

## 동작 확인

![스크린샷 2024-04-18 오전 12 36 16](https://github.com/jirum-alarm/jirum-alarm-frontend/assets/50096419/4d77b41b-d3c6-405d-9e00-c4205f95b7b0)

