### PR TITLE
[fix] ios 웹뷰에서 이메일 로그인시 비밀번호 인풋 가리는 문제 수정

### DIFF
--- a/src/app/login/email/components/EmailLoginForm.tsx
+++ b/src/app/login/email/components/EmailLoginForm.tsx
@@ -11,7 +11,7 @@ import { isIOSFlutterWeb } from '@/util/ua';
 const EmailLoginForm = () => {
   const { email, password, error, handleSubmit } = useEmailLoginFormViewModel();
 
-  const buttonRef = useRef<HTMLButtonElement>(null);
+  const buttonRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const handleFocusIn = (e: FocusEvent) => {
@@ -59,14 +59,17 @@ const EmailLoginForm = () => {
     <form onSubmit={handleSubmit} className="flex flex-1 flex-col justify-between pt-11">
       <EmailInput email={email} />
       <PasswordInput password={password} />
-      <div className="h-32" />
-      <div className="fixed bottom-0 left-0 right-0 m-auto w-full max-w-[480px] bg-white px-5 pb-9 pt-3">
+      <div className="h-96" />
+      <div
+        ref={buttonRef}
+        className="fixed bottom-0 left-0 right-0 m-auto w-full max-w-[480px] bg-white px-5 pb-9 pt-3"
+      >
         {error && (
           <p className="pb-4 text-center text-sm text-error-500">
             이메일 혹은 비밀번호가 올바르지 않아요.
           </p>
         )}
-        <Button type="submit" disabled={!true} ref={buttonRef}>
+        <Button type="submit" disabled={!true}>
           로그인
         </Button>
       </div>

--- a/src/app/login/email/components/EmailLoginForm.tsx
+++ b/src/app/login/email/components/EmailLoginForm.tsx
@@ -5,10 +5,55 @@ import { cn } from '@/lib/cn';
 import Input from '@/components/common/Input';
 import { Cancel, Eye, EyeOff } from '@/components/common/icons';
 import useEmailLoginFormViewModel from '../hooks/useEmailLoginFormViewModel';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { isIOSFlutterWeb } from '@/util/ua';
 
 const EmailLoginForm = () => {
   const { email, password, error, handleSubmit } = useEmailLoginFormViewModel();
+
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    const handleFocusIn = (e: FocusEvent) => {
+      if (!isIOSFlutterWeb()) {
+        return;
+      }
+
+      if (buttonRef.current === null || e.target === null) {
+        return;
+      }
+
+      const target = e.target as HTMLElement;
+
+      if (target.tagName === 'INPUT') {
+        buttonRef.current.style.display = 'none';
+      }
+    };
+
+    const handleFocusOut = (e: FocusEvent) => {
+      if (!isIOSFlutterWeb()) {
+        return;
+      }
+
+      if (buttonRef.current === null || e.target === null) {
+        return;
+      }
+
+      const target = e.target as HTMLElement;
+
+      if (target.tagName === 'INPUT') {
+        buttonRef.current.style.display = 'block';
+      }
+    };
+
+    document.addEventListener('focusin', handleFocusIn);
+    document.addEventListener('focusout', handleFocusOut);
+
+    return () => {
+      document.removeEventListener('focusin', handleFocusIn);
+      document.removeEventListener('focusout', handleFocusOut);
+    };
+  }, []);
 
   return (
     <form onSubmit={handleSubmit} className="flex flex-1 flex-col justify-between pt-11">
@@ -21,7 +66,7 @@ const EmailLoginForm = () => {
             이메일 혹은 비밀번호가 올바르지 않아요.
           </p>
         )}
-        <Button type="submit" disabled={!true}>
+        <Button type="submit" disabled={!true} ref={buttonRef}>
           로그인
         </Button>
       </div>


### PR DESCRIPTION
resolve #185<!-- 모든 섹션은 꼭 다 채우지 않아도 됩니다! -->

## 구현한 것

<!-- PR에서 구현하여 확인해주었으면 하는 것을 적어주세요 -->

인풋 포커스시 하단에 버튼 영역을 안보이게 했습니다! 추가로 비밀번호 포커스시 여백 넉넉하게 줘서 포커스 잘가게 바꿨음당

## 구현하지 않은 것

<!-- PR에서 구현하지 않아 확인하지 않아도 되는 것을 적어주세요 -->

## 동작 확인

https://github.com/jirum-alarm/jirum-alarm-frontend/assets/50096419/4a88b179-ddeb-429d-b464-c9dfab594e31



<!-- PR의 동작을 확인할 수 있는 스크린샷이나 영상 혹은 방법을 추가해주세요 -->
