### PR TITLE
[misc] 잡다한 여러 변경 적용

### DIFF
--- a/src/app/(home)/components/SearchInput.tsx
+++ b/src/app/(home)/components/SearchInput.tsx
@@ -3,8 +3,8 @@ import { useSearchInputViewModel } from '../hooks/useSearchInputViewModel';
 const SearchInput = () => {
   const { inputRef, onKeyDown, handleReset } = useSearchInputViewModel();
   return (
-    <div className="mb-6 drop-shadow-md">
-      <div className="relative mt-6 flex h-14 w-full items-center overflow-hidden rounded-lg bg-white shadow hover:shadow-md">
+    <div className="mb-4 drop-shadow-md">
+      <div className="relative mt-4 flex h-14 w-full items-center overflow-hidden rounded-lg bg-white shadow-sm hover:shadow-md">
         <div className="grid h-full w-14 place-items-center text-gray-300">
           <svg
             xmlns="http://www.w3.org/2000/svg"

--- a/src/app/alarm/components/AlarmItem.tsx
+++ b/src/app/alarm/components/AlarmItem.tsx
@@ -9,10 +9,10 @@ const AlarmItem = ({ notification }: { notification: INotification }) => {
       <div>
         <Hotdeal />
       </div>
-      <Link href={notification.url ?? ''}>
+      <a href={notification.url ?? ''} target="_blank" rel="noopener noreferrer">
         <p className="text-sm">{notification.message}</p>
         <span className="text-xs text-gray-400">{displayTime(notification.createdAt)}</span>
-      </Link>
+      </a>
     </li>
   );
 };

--- a/src/app/login/email/components/EmailLoginForm.tsx
+++ b/src/app/login/email/components/EmailLoginForm.tsx
@@ -94,9 +94,9 @@ const PasswordInput = ({
         value={password.value}
         icon={
           masking ? (
-            <Eye onClick={toggleMasking} className="cursor-pointer text-gray-400" />
-          ) : (
             <EyeOff onClick={toggleMasking} className="cursor-pointer" />
+          ) : (
+            <Eye onClick={toggleMasking} className="cursor-pointer text-gray-400" />
           )
         }
         helperText={

--- a/src/app/login/email/hooks/useEmailLoginFormViewModel.ts
+++ b/src/app/login/email/hooks/useEmailLoginFormViewModel.ts
@@ -4,6 +4,7 @@ import { ILoginOutput, ILoginVariable } from '@/types/login';
 import { useMutation } from '@apollo/client';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
+import { useToast } from '../../../../components/common/Toast';
 
 const HOME_PATH = '/';
 
@@ -20,6 +21,8 @@ interface Login {
 }
 
 const useEmailLoginFormViewModel = () => {
+  const { toast } = useToast();
+
   const [loginForm, setLoginForm] = useState<Login>({
     email: {
       value: '',
@@ -46,6 +49,7 @@ const useEmailLoginFormViewModel = () => {
         localStorage.setItem(StorageTokenKey.REFRESH_TOKEN, data.login.refreshToken);
       }
 
+      toast('로그인에 성공했어요.');
       router.replace(HOME_PATH);
     },
     onError: () => {

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -16,11 +16,11 @@ const Login = () => {
   };
 
   return (
-    <BasicLayout hasBackButton fullScreen={false}>
-      <div className="h-full px-5 py-9">
-        <div className="grid h-full text-center">
+    <BasicLayout hasBackButton fullScreen={true}>
+      <div className="h-full py-32">
+        <div className="grid text-center">
           <div>
-            <div className="grid justify-center pb-5">
+            <div className="grid justify-center">
               <Illust size="sm" />
             </div>
             <div>

--- a/src/app/mypage/account/password/components/PasswordInput.tsx
+++ b/src/app/mypage/account/password/components/PasswordInput.tsx
@@ -40,9 +40,9 @@ const PasswordInput = ({
         value={value}
         icon={
           masking ? (
-            <Eye onClick={toggleMasking} className="cursor-pointer" />
-          ) : (
             <EyeOff onClick={toggleMasking} className="cursor-pointer" />
+          ) : (
+            <Eye onClick={toggleMasking} className="cursor-pointer" />
           )
         }
         helperText={helperText}

--- a/src/app/mypage/account/personal/components/PersonalInfoForm.tsx
+++ b/src/app/mypage/account/personal/components/PersonalInfoForm.tsx
@@ -11,7 +11,6 @@ const PersonalInfoForm = () => {
     handleSubmit,
     handleSelectChange,
     handleRadioChange,
-    isValidPersonalInfoInput,
     birthYearOptions,
   } = usePersonalInfoFormViewModel();
   return (
@@ -25,9 +24,7 @@ const PersonalInfoForm = () => {
         <div className="h-10" />
         <GenderRadioGroup handleRadioChange={handleRadioChange} gender={gender} />
       </div>
-      <Button type="submit" disabled={isValidPersonalInfoInput()}>
-        저장
-      </Button>
+      <Button type="submit">저장</Button>
     </form>
   );
 };

--- a/src/app/mypage/categories/components/CategoriesForm.tsx
+++ b/src/app/mypage/categories/components/CategoriesForm.tsx
@@ -5,14 +5,12 @@ import CategoriesCheckboxGroup from '@/features/categories/components/Categories
 import { MAX_SELECTION_COUNT } from '@/constants/categories';
 
 const CategoriesForm = () => {
-  const { handleSubmit, handleCheckChange, categories, canSubmit, SELECTION_COUNT } =
+  const { handleSubmit, handleCheckChange, categories, SELECTION_COUNT } =
     useCategoriesFormViewModel();
   return (
     <form className="flex flex-1 flex-col justify-between" onSubmit={handleSubmit}>
       <CategoriesCheckboxGroup categories={categories} handleCheckChange={handleCheckChange} />
-      <Button type="submit" disabled={!canSubmit()}>
-        {`저장 (${SELECTION_COUNT}/${MAX_SELECTION_COUNT})`}
-      </Button>
+      <Button type="submit">{`저장 (${SELECTION_COUNT}/${MAX_SELECTION_COUNT})`}</Button>
     </form>
   );
 };

--- a/src/app/mypage/categories/page.tsx
+++ b/src/app/mypage/categories/page.tsx
@@ -4,7 +4,7 @@ import CategoriesForm from './components/CategoriesForm';
 
 const CategoriesPage = () => {
   return (
-    <BasicLayout hasBackButton title="관심카테고리 수정">
+    <BasicLayout hasBackButton title="관심 카테고리 수정">
       <div className="h-full px-5 pb-8 pt-6">
         <fieldset className="flex h-full flex-col">
           <legend>

--- a/src/app/signup/password/components/PasswordForm.tsx
+++ b/src/app/signup/password/components/PasswordForm.tsx
@@ -70,9 +70,9 @@ const PasswordInput = ({
         value={value}
         icon={
           masking ? (
-            <Eye onClick={toggleMasking} className="cursor-pointer" />
-          ) : (
             <EyeOff onClick={toggleMasking} className="cursor-pointer" />
+          ) : (
+            <Eye onClick={toggleMasking} className="cursor-pointer" />
           )
         }
         /** @MEMO 헬퍼 텍스트에서 조건에 맞거나 틀린 경우 색을 바꾸는 형태라 errorText를 의도적으로 사용하지 않았음

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -21,7 +21,7 @@ export default function NavBar() {
     { skip: IS_VERCEL_PRD || !data?.me },
   );
 
-  const layoutPaddingTop = isIOSFlutterWeb() ? 'pt-4' : 'pt-8';
+  const layoutPaddingTop = isIOSFlutterWeb() ? 'pt-4' : 'pt-6';
 
   return (
     <>

--- a/src/components/common/Input/variant/input.ts
+++ b/src/components/common/Input/variant/input.ts
@@ -43,7 +43,7 @@ export const inputVariant = cva(
         standard: ['border-b', 'placeholder:text-gray-400', 'rounded-none'],
       },
       size: {
-        md: ['text-base', 'px-2', 'py-3'],
+        md: ['text-base', 'px-1', 'py-3'],
       },
       color: {
         black: ['text-gray-900', 'border-gray-400', 'focus:border-gray-900'],

--- a/src/components/common/Toast/useToast.tsx
+++ b/src/components/common/Toast/useToast.tsx
@@ -1,7 +1,7 @@
 import { Toast } from './Toast';
 import { useEffect, useState } from 'react';
 
-const TOAST_REMOVE_DELAY = 3000;
+const TOAST_REMOVE_DELAY = 2000;
 
 interface Toast {
   id: string;


### PR DESCRIPTION
## 구현한 것

- 메인화면 여백 축소
- 알림센터에서 알림 클릭시 외부 링크로 랜딩
- 로그인 페이지 상단 여백 추가
- 비밀번호 가리기/보이기 아이콘 반대로 적용
- 로그인 성공 토스트 추가
- 문구 수정 `관심카테고리 수정` -> `관심 카테고리 수정`
- 마이페이지 정보 변경시 수정하지 않은 상태에서도 저장버튼 누를 수 있도록 변경
- 인풋의 좌측 여백 축소
- 토스트 시간 감소 3초 -> 2초

## 동작 확인

-  메인화면 여백 축소

<img width="400" alt="image" src="https://github.com/jirum-alarm/jirum-alarm-frontend/assets/39974627/b518918c-7c60-4f8e-a134-18aa314deaab">

- 알림센터에서 알림 클릭시 외부 링크로 랜딩

<img width="400" alt="image" src="https://github.com/jirum-alarm/jirum-alarm-frontend/assets/39974627/657015bd-9577-4029-aa70-ae6a662549d7">

- 로그인 페이지 상단 여백 추가

<img width="400" alt="image" src="https://github.com/jirum-alarm/jirum-alarm-frontend/assets/39974627/0404e46b-f48f-462b-8350-0a756118f312">

- 비밀번호 가리기/보이기 아이콘 반대로 적용

<img width="400" alt="image" src="https://github.com/jirum-alarm/jirum-alarm-frontend/assets/39974627/d7569533-d25b-4821-ae14-c868e35d4456">

- 로그인 성공 토스트 추가

<img width="300" alt="image" src="https://github.com/jirum-alarm/jirum-alarm-frontend/assets/39974627/890ca28f-2ef5-4073-a452-9e01ceeaf2ef">

- 문구 수정 `관심카테고리 수정` -> `관심 카테고리 수정`

<img width="150" alt="image" src="https://github.com/jirum-alarm/jirum-alarm-frontend/assets/39974627/3947ffa1-7dfd-41c2-81b4-8771eb7bece6">

- 마이페이지 정보 변경시 수정하지 않은 상태에서도 저장버튼 누를 수 있도록 변경

<img width="400" alt="image" src="https://github.com/jirum-alarm/jirum-alarm-frontend/assets/39974627/ad082ce1-fa46-4de9-aec1-f09ccdb08caa">

- 인풋의 좌측 여백 축소

<img width="400" alt="image" src="https://github.com/jirum-alarm/jirum-alarm-frontend/assets/39974627/f6c25698-2964-4f17-924e-408f3986c3d7">

- 토스트 시간 감소 3초 -> 2초

<img width="300" alt="image" src="https://github.com/jirum-alarm/jirum-alarm-frontend/assets/39974627/890ca28f-2ef5-4073-a452-9e01ceeaf2ef">
