### PR TITLE
상품 검색 이벤트 트래킹 추가

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,7 @@ const withPWA = require('next-pwa')({
   skipWaiting: true,
   runtimeCaching,
   buildExcludes: [/middleware-manifest.json$/],
+  disableDevLogs: true,
 });
 
 const sentryWebpackPluginOptions = {

--- a/src/app/(home)/hooks/useSearchInputViewModel.ts
+++ b/src/app/(home)/hooks/useSearchInputViewModel.ts
@@ -1,3 +1,4 @@
+import { mp } from '@/lib/mixpanel';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useRef } from 'react';
 
@@ -14,6 +15,10 @@ export const useSearchInputViewModel = () => {
       current.set('keyword', inputRef.current.value);
       const search = current.toString();
       router.replace(`/?${search}`);
+
+      mp.track('Product Search', {
+        keyword: current.get('keyword'),
+      });
     }
   };
   const handleReset = () => {

--- a/src/lib/mixpanel.ts
+++ b/src/lib/mixpanel.ts
@@ -18,6 +18,12 @@ class MixpanelService {
         ignore_dnt: true,
       });
       MixpanelService.instance = mixpanel;
+    } else {
+      // mock when not prd
+      MixpanelService.instance = {} as any;
+      MixpanelService.instance.track = (event: string, props?: any) => {
+        console.info('Mixpanel track:', event, props);
+      };
     }
 
     return MixpanelService.instance;


### PR DESCRIPTION
<!-- 모든 섹션은 꼭 다 채우지 않아도 됩니다! -->

## 구현한 것

<!-- PR에서 구현하여 확인해주었으면 하는 것을 적어주세요 -->

- 홈 화면에서 상품 검색시 이벤트 트래킹하는 코드 추가했슴당
- 나오지 않아도 되는 에러, 워닝 로그들 지웠습니당

## 구현하지 않은 것

<!-- PR에서 구현하지 않아 확인하지 않아도 되는 것을 적어주세요 -->

## 동작 확인

<!-- PR의 동작을 확인할 수 있는 스크린샷이나 영상 혹은 방법을 추가해주세요 -->

- 개발 환경에서는 트래킹이 로그로만 나옴
 
![스크린샷 2024-05-18 오전 1 37 56](https://github.com/jirum-alarm/jirum-alarm-frontend/assets/50096419/80c70609-859f-4e1a-a0b5-b77b7f24c2dd)



