### PR TITLE
[feature] 검색 페이지 인풋창 사이즈 개선

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "theme_color": "#9EF22E",
-  "background_color": "#0056b3",
+  "theme_color": "#FFFFFF",
+  "background_color": "#9EF22E",
   "display": "standalone",
   "scope": "/",
   "start_url": "/",

--- a/src/app/search/components/SearchInput.tsx
+++ b/src/app/search/components/SearchInput.tsx
@@ -14,7 +14,7 @@ const SearchInput = ({ show }: { show: boolean }) => {
     <>
       <div
         className={cn(
-          'fixed z-50 flex w-[calc(100vw-2.5rem)] max-w-screen-lg items-center justify-between gap-x-3 rounded bg-white py-4',
+          'fixed z-50  ml-[-20px] flex w-full  max-w-screen-lg items-center justify-between gap-x-3 rounded bg-white px-5 py-4',
           show
             ? 'flex opacity-100 transition-opacity duration-150'
             : 'opacity-0 transition-opacity duration-150',


### PR DESCRIPTION
<!-- 모든 섹션은 꼭 다 채우지 않아도 됩니다! -->

## 구현한 것

<!-- PR에서 구현하여 확인해주었으면 하는 것을 적어주세요 -->
- 검색 페이지 인풋창 사이즈 화면에 꽉 맞게 변경
- pwa 테마 컬러 (화면 여백) 색 배경색과 통일 (배경색과 달라 이질감 + 배경색과 다르면 검색 인풋과 같이 고정된 요소가 떠 다니는 것처럼 보임)
   - 테마 (여백) 로고 연두색에서 흰색으로 변경
   - 백그라운드 (스플래시 로딩 색) 파랑색에서 로고 연두색으로 변경
## 구현하지 않은 것

<!-- PR에서 구현하지 않아 확인하지 않아도 되는 것을 적어주세요 -->

## 동작 확인

<!-- PR의 동작을 확인할 수 있는 스크린샷이나 영상 혹은 방법을 추가해주세요 -->

- 화면 예시를 위해 배경색 cyan으로 변경, 인풋의 여백을 배경색(흰색으로 두어)으로 채워 위화감을 낮춤

![스크린샷 2024-05-23 오후 10 42 10](https://github.com/jirum-alarm/jirum-alarm-frontend/assets/50096419/592540de-0f45-4f1f-b87f-530ebfdff2ae)

