### PR TITLE
[fix] 검색 페이지 검색 리셋시 다른 상품들이 잠깐 보이는 버그 수정

### DIFF
--- a/src/app/search/hooks/useProductListViewModel.ts
+++ b/src/app/search/hooks/useProductListViewModel.ts
@@ -22,6 +22,7 @@ export const useProductListViewModel = () => {
       limit,
       keyword: keywordParam || undefined,
     },
+    skip: !keywordParam,
   });
 
   const { ref } = useInView({


### PR DESCRIPTION
<!-- 모든 섹션은 꼭 다 채우지 않아도 됩니다! -->

## 구현한 것

<!-- PR에서 구현하여 확인해주었으면 하는 것을 적어주세요 -->

리셋시 다른 상품들이 잠깐 보이는 버그가 있어 사용자에게 위화감을 주기 때문에 수정


## 구현하지 않은 것

<!-- PR에서 구현하지 않아 확인하지 않아도 되는 것을 적어주세요 -->

## 동작 확인

<!-- PR의 동작을 확인할 수 있는 스크린샷이나 영상 혹은 방법을 추가해주세요 -->


- 리셋시 잠시동안 초기 아이템들이 보임

https://github.com/jirum-alarm/jirum-alarm-frontend/assets/50096419/e1e25624-90c7-474f-a075-5089c4c28870


- 리셋시 잠시동안 보이던 초기 아이템들이 안보임 (상품이 없습니다. 메시지가 보이지만 여백이 대부분이기 때문에 위화감 없음)

https://github.com/jirum-alarm/jirum-alarm-frontend/assets/50096419/9cb43605-898b-4cd4-aa17-8bb620b3bd4d


