### PR TITLE
[fix] 핫딜 리스트 랜덤 카운트 변경

### DIFF
--- a/apps/web/src/features/products/hooks/useHotdeals.ts
+++ b/apps/web/src/features/products/hooks/useHotdeals.ts
@@ -8,6 +8,8 @@ import {
 import { useQuery } from '@apollo/client';
 
 export const HOT_DEAL_LIMIT = 20;
+
+const HOT_DEAL_COUNT_RANDOM = 20;
 const HOT_DEAL_LIMIT_RANDOM = 10;
 
 export const useHotDeals = ({
@@ -30,12 +32,15 @@ export const useHotDeals = ({
   return result;
 };
 
-export const useHotDealsRandom = ({ limit = HOT_DEAL_LIMIT_RANDOM }: { limit?: number } = {}) => {
+export const useHotDealsRandom = ({
+  count = HOT_DEAL_COUNT_RANDOM,
+  limit = HOT_DEAL_LIMIT_RANDOM,
+}: { count?: number; limit?: number } = {}) => {
   const result = useQuery<CommunityRandomRankingProductsOutPut>(
     QueryCommunityRandomRankingProducts,
     {
       variables: {
-        count: 10,
+        count,
         limit,
         isApp: false,
         isReward: false,


### PR DESCRIPTION
<!-- 모든 섹션은 꼭 다 채우지 않아도 됩니다! -->

## 구현한 것

<!-- PR에서 구현하여 확인해주었으면 하는 것을 적어주세요 -->
기존 핫딜 랜덤을 10개에서 섞다보니 다양하게 보여주지 못해서 20으로 변경했음다

## 구현하지 않은 것

<!-- PR에서 구현하지 않아 확인하지 않아도 되는 것을 적어주세요 -->

## 동작 확인

<!-- PR의 동작을 확인할 수 있는 스크린샷이나 영상 혹은 방법을 추가해주세요 -->
- 여러가지 핫딜들이 다양하게 보임
![스크린샷 2024-06-07 오후 11 49 24](https://github.com/jirum-alarm/jirum-alarm-frontend/assets/50096419/04888e46-62f5-4387-8753-64f109c626c2)
![스크린샷 2024-06-07 오후 11 49 29](https://github.com/jirum-alarm/jirum-alarm-frontend/assets/50096419/c2ea4b1c-0c1a-49c0-8d50-22e9d78fef37)


