### PR TITLE
refactor(admin): mutation이후 리스트 api호출을 cache 업데이트로 변경

### DIFF
--- a/apps/admin/src/app/hotdeal/keyword/update/[keywordId]/page.tsx
+++ b/apps/admin/src/app/hotdeal/keyword/update/[keywordId]/page.tsx
@@ -2,14 +2,12 @@
 import DefaultLayout from '@/components/Layouts/DefaultLayout';
 import Card from '@/components/Card';
 import { useState } from 'react';
-import { HotDealKeywordOrderType, HotDealKeywordType, OrderOptionType } from '@/types/keyword';
+import { HotDealKeywordType } from '@/types/keyword';
 import { useGetHotDealDetailKeyword, useUpdateHotDealKeyword } from '@/hooks/graphql/keyword';
 import { useRouter } from 'next/navigation';
 import WeightSetter from '../../components/WeightSetter';
 import PrimaryKeyword from '../../components/PrimaryKeywordForm';
 import { HotDealKeywordTypeMap } from '@/constants/hotdeal';
-import { QueryHotDealKeywordsByAdmin } from '@/graphql/keyword';
-import { PAGE_LIMIT } from '@/constants/limit';
 
 interface KeywordFormType {
   type: HotDealKeywordType;
@@ -47,7 +45,7 @@ const KeywordUpdatePage = ({ params }: Props) => {
   const [mutate, { loading }] = useUpdateHotDealKeyword(keyword.type, {
     onCompleted: () => {
       alert('키워드 수정 성공!');
-      router.push(`/hotdeal/keyword?keywordType=${keyword.type}`);
+      router.back();
     },
   });
   const handleChangeWeight = (value: number) => {

--- a/apps/admin/src/components/Layouts/DefaultLayout.tsx
+++ b/apps/admin/src/components/Layouts/DefaultLayout.tsx
@@ -14,7 +14,7 @@ export default function DefaultLayout({ children }: { children: React.ReactNode 
         {/* <!-- ===== Sidebar End ===== --> */}
 
         {/* <!-- ===== Content Area Start ===== --> */}
-        <div className="relative ml-72.5 flex flex-1 flex-col">
+        <div className="relative flex flex-1 flex-col lg:ml-72.5">
           {/* <!-- ===== Header Start ===== --> */}
           <Header sidebarOpen={sidebarOpen} setSidebarOpen={setSidebarOpen} />
           {/* <!-- ===== Header End ===== --> */}

--- a/apps/admin/src/hooks/graphql/keyword.ts
+++ b/apps/admin/src/hooks/graphql/keyword.ts
@@ -28,7 +28,7 @@ export const useAddHotDealKeyword = (
   keywordType: HotDealKeywordType,
   options?: MutationHookOptions<any, AddHotDealKeywordVariable>,
 ) => {
-  return useMutation<{ data: { addHotDealKeywordByAdmin: boolean } }, AddHotDealKeywordVariable>(
+  return useMutation<{ addHotDealKeywordByAdmin: boolean }, AddHotDealKeywordVariable>(
     MutationAddHotDealKeywordByAdmin,
     {
       refetchQueries: [
@@ -55,23 +55,40 @@ export const useRemoveHotDealKeyword = (
   keywordType: HotDealKeywordType,
   options?: MutationHookOptions<any, removeHotDealKeywordVariables>,
 ) => {
-  return useMutation<
-    { data: { removeHotDealKeywordByAdmin: boolean } },
-    removeHotDealKeywordVariables
-  >(MutationRemoveHotDealKeywordByAdmin, {
-    refetchQueries: [
-      {
-        query: QueryHotDealKeywordsByAdmin,
-        variables: {
-          type: keywordType,
-          orderBy: HotDealKeywordOrderType.ID,
-          orderOption: OrderOptionType.ASC,
-          limit: PAGE_LIMIT,
-        },
+  return useMutation<{ removeHotDealKeywordByAdmin: boolean }, removeHotDealKeywordVariables>(
+    MutationRemoveHotDealKeywordByAdmin,
+    {
+      update(cache, { data }, option) {
+        const { variables } = option;
+        const existingKeywords = cache.readQuery({
+          query: QueryHotDealKeywordsByAdmin,
+          variables: {
+            type: keywordType,
+            orderBy: HotDealKeywordOrderType.ID,
+            orderOption: OrderOptionType.ASC,
+            limit: PAGE_LIMIT,
+          },
+        }) as { hotDealKeywordsByAdmin: GetHotDealKeywordsData[] } | null;
+        if (existingKeywords?.hotDealKeywordsByAdmin.length && data?.removeHotDealKeywordByAdmin) {
+          cache.writeQuery({
+            query: QueryHotDealKeywordsByAdmin,
+            variables: {
+              type: keywordType,
+              orderBy: HotDealKeywordOrderType.ID,
+              orderOption: OrderOptionType.ASC,
+              limit: PAGE_LIMIT,
+            },
+            data: {
+              hotDealKeywordsByAdmin: existingKeywords.hotDealKeywordsByAdmin.filter(
+                (keyword) => Number(keyword.id) !== variables?.id,
+              ),
+            },
+          });
+        }
       },
-    ],
-    ...options,
-  });
+      ...options,
+    },
+  );
 };
 
 interface updateHotDealKeywordVariables {
@@ -85,23 +102,23 @@ export const useUpdateHotDealKeyword = (
   keywordType: HotDealKeywordType,
   options?: MutationHookOptions<any, updateHotDealKeywordVariables>,
 ) => {
-  return useMutation<
-    { data: { updateHotDealKeywordByAdmin: boolean } },
-    updateHotDealKeywordVariables
-  >(MutationUpdateHotDealKeywordByAdmin, {
-    refetchQueries: [
-      {
-        query: QueryHotDealKeywordsByAdmin,
-        variables: {
-          type: keywordType,
-          orderBy: HotDealKeywordOrderType.ID,
-          orderOption: OrderOptionType.ASC,
-          limit: PAGE_LIMIT,
+  return useMutation<{ updateHotDealKeywordByAdmin: boolean }, updateHotDealKeywordVariables>(
+    MutationUpdateHotDealKeywordByAdmin,
+    {
+      refetchQueries: [
+        {
+          query: QueryHotDealKeywordsByAdmin,
+          variables: {
+            type: keywordType,
+            orderBy: HotDealKeywordOrderType.ID,
+            orderOption: OrderOptionType.ASC,
+            limit: PAGE_LIMIT,
+          },
         },
-      },
-    ],
-    ...options,
-  });
+      ],
+      ...options,
+    },
+  );
 };
 
 interface GetHotDealKeywordsData {


### PR DESCRIPTION
<!-- 모든 섹션은 꼭 다 채우지 않아도 됩니다! -->

## 구현한 것
- 키워드 리스트에서 삭제나 수정시 QueryHotDealKeywordsByAdmin api를 처음부터 호출해야하는 상황을 개선
- QueryHotDealKeywordsByAdmin의 캐시 업데이트를 개선하여 키워드 삭제 후에도 스크롤 상태를 유지하도록 함
<!-- PR에서 구현하여 확인해주었으면 하는 것을 적어주세요 -->

## 구현하지 않은 것

<!-- PR에서 구현하지 않아 확인하지 않아도 되는 것을 적어주세요 -->

## 동작 확인

https://github.com/jirum-alarm/jirum-alarm-frontend/assets/89559826/fe05b312-8fc6-4db1-a2a5-8be9ab6557fa


<!-- PR의 동작을 확인할 수 있는 스크린샷이나 영상 혹은 방법을 추가해주세요 -->
