### PR TITLE
[feature] 검색창 진입 단축키 `/`

### DIFF
--- a/apps/web/src/app/(home)/components/SearchInput.tsx
+++ b/apps/web/src/app/(home)/components/SearchInput.tsx
@@ -1,4 +1,21 @@
+import { useCallback, useEffect } from 'react';
+
 const SearchInput = ({ goSearchPage }: { goSearchPage: () => void }) => {
+  const handleKeyPress = useCallback((event: KeyboardEvent) => {
+    const isInputEvent = event.target && (event.target as HTMLInputElement).tagName === 'INPUT';
+    if (event.key === '/' && !isInputEvent) {
+      event.preventDefault();
+      goSearchPage();
+    }
+  }, []);
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyPress);
+    return () => {
+      document.removeEventListener('keydown', handleKeyPress);
+    };
+  }, [handleKeyPress]);
+
   return (
     <div onClick={goSearchPage} className="mb-4 cursor-pointer rounded bg-gray-50">
       <div className="relative mt-4 flex w-full items-center overflow-hidden">
@@ -20,6 +37,9 @@ const SearchInput = ({ goSearchPage }: { goSearchPage: () => void }) => {
         </div>
         <div className="flex h-full w-full items-center pr-2 text-sm text-gray-400 outline-none">
           핫딜 제품을 검색해 주세요
+        </div>
+        <div className="mr-2 flex h-[24px] w-[24px] items-center justify-center rounded-[4px] bg-gray-200 text-center text-[15px] leading-[20px] text-gray-400">
+          /
         </div>
       </div>
     </div>


### PR DESCRIPTION
## 구현한 것
- 검색창에 진입하기 위한 단축키 추가
  - "/"키를 눌렀을 때 검색창으로 포커스가 이동됨

## 변경사항
- "/"키를 감지하는 키보드 이벤트 리스너를 추가했습니다.
- "/"키를 누르면 검색창으로 포커스가 즉시 이동되어 사용자가 즉시 검색어를 입력할 수 있습니다. 
- 다른 입력 필드나 텍스트 필드와의 충돌을 방지하기 위한 검사를 포함했습니다.

## 이점
- 사용자는 스크롤을 올리지 않고도 검색창에 빠르게 접근할 수 있어 사용자 경험이 더욱 향상됩니다.
- 이 단축키는 키보드 내비게이션을 선호하는 사용자들에게 빠르고 편리한 검색 기능 접근 방법을 제공합니다.

## 테스트
- 다양한 페이지에서 수동으로 테스트해 단축키가 예상대로 작동하는지 확인했습니다.
- "/"키가 다른 입력 필드나 기존의 단축키와 충돌하지 않도록 확인했습니다.

## 구현하지 않은 것

## 동작 확인
https://github.com/jirum-alarm/jirum-alarm-frontend/assets/124853691/d0afe645-955c-4b8e-bee8-1d3d5b84b8bf
