### PR TITLE
fix(web): 미들웨어단에서 쿠키세팅시 문제

### DIFF
--- a/apps/web/src/app/(home)/page.tsx
+++ b/apps/web/src/app/(home)/page.tsx
@@ -2,7 +2,6 @@ import AddFCMToken from './components/AddFCMToken';
 import HomeContainer from './components/HomeContainer';
 import HomeContainerV2 from './components/(home)/HomeContainerV2';
 import { getFeatureFlag } from '../actions/posthog';
-// .
 
 export default async function Home() {
   const { flags } = await getFeatureFlag();

--- a/apps/web/src/app/(home)/page.tsx
+++ b/apps/web/src/app/(home)/page.tsx
@@ -2,6 +2,7 @@ import AddFCMToken from './components/AddFCMToken';
 import HomeContainer from './components/HomeContainer';
 import HomeContainerV2 from './components/(home)/HomeContainerV2';
 import { getFeatureFlag } from '../actions/posthog';
+// .
 
 export default async function Home() {
   const { flags } = await getFeatureFlag();

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -30,7 +30,7 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
 
   let distinct_id;
   if (cookie) {
-    distinct_id = JSON.parse(cookie?.value).distinct_id;
+    distinct_id = JSON.parse(cookie.value).distinct_id;
   } else {
     distinct_id = crypto.randomUUID();
   }

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,5 +1,27 @@
 // middleware.js
 import { NextRequest, NextResponse } from 'next/server';
+import { ResponseCookies, RequestCookies } from 'next/dist/server/web/spec-extension/cookies';
+
+/**
+ * Copy cookies from the Set-Cookie header of the response to the Cookie header of the request,
+ * so that it will appear to SSR/RSC as if the user already has the new cookies.
+ */
+function applySetCookie(req: NextRequest, res: NextResponse): void {
+  // parse the outgoing Set-Cookie header
+  const setCookies = new ResponseCookies(res.headers);
+  // Build a new Cookie header for the request by adding the setCookies
+  const newReqHeaders = new Headers(req.headers);
+  const newReqCookies = new RequestCookies(newReqHeaders);
+  setCookies.getAll().forEach((cookie) => newReqCookies.set(cookie));
+  // set “request header overrides” on the outgoing response
+  NextResponse.next({
+    request: { headers: newReqHeaders },
+  }).headers.forEach((value, key) => {
+    if (key === 'x-middleware-override-headers' || key.startsWith('x-middleware-request-')) {
+      res.headers.set(key, value);
+    }
+  });
+}
 
 export async function middleware(request: NextRequest): Promise<NextResponse> {
   const ph_project_api_key = process.env.NEXT_PUBLIC_POSTHOG_KEY;
@@ -8,7 +30,7 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
 
   let distinct_id;
   if (cookie) {
-    distinct_id = JSON.parse(cookie.value).distinct_id;
+    distinct_id = JSON.parse(cookie?.value).distinct_id;
   } else {
     distinct_id = crypto.randomUUID();
   }
@@ -31,13 +53,24 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
 
   const data = await ph_request.json();
 
+  const response = NextResponse.next({
+    request: {
+      headers: new Headers(request.headers),
+    },
+  });
+
   const bootstrapData = {
     distinctID: distinct_id,
     featureFlags: data.featureFlags,
   };
 
-  const response = NextResponse.next();
-  response.cookies.set('bootstrapData', JSON.stringify(bootstrapData));
+  const cookieInfo = {
+    name: 'bootstrapData',
+    value: JSON.stringify(bootstrapData),
+  };
+
+  response.cookies.set(cookieInfo);
+  applySetCookie(request, response);
 
   return response;
 }


### PR DESCRIPTION
<!-- 모든 섹션은 꼭 다 채우지 않아도 됩니다! -->

## 구현한 것
> 페이지 로드 시, 미들웨어와 서버 컴포넌트는 브라우저가 서버에 요청을 보내고, 서버가 해당 요청을 처리한 후 응답하는 일련의 과정 내에서 동작해서 문제가 있었습니다.

- 미들웨어에서 쿠키를 설정을 하면 응답의 Set-Cookie 헤더에 포함이 되고
- server action에선 이미 들어온 요청의 헤더에 Cookies 값에서 cookie를 찾기 때문에 미들웨어에서 설정한 cookie를 가져오지 못하는 문제가 있었습니다.
- 미들웨어단에서 서버 컴포넌트 요청의 Cookie 헤더 값을 오버라이드할 수 있도록 로직을 추가했습니다.

## 구현하지 않은 것

<!-- PR에서 구현하지 않아 확인하지 않아도 되는 것을 적어주세요 -->

## 동작 확인

<!-- PR의 동작을 확인할 수 있는 스크린샷이나 영상 혹은 방법을 추가해주세요 -->
