### PR TITLE
feature(web): 사파리 상태바 색상 고정

### DIFF
--- a/apps/web/src/app/(home)/components/(home)/BackgroundHeader.tsx
+++ b/apps/web/src/app/(home)/components/(home)/BackgroundHeader.tsx
@@ -1,25 +1,11 @@
 'use client';
 
-import { useEffect } from 'react';
-
 import { RoundedLogo } from '@/components/common/icons';
 import SearchLinkButton from '@/components/SearchLinkButton';
 import Link from '@/features/Link';
 import { cn } from '@/lib/cn';
 
 const BackgroundHeader = () => {
-  useEffect(() => {
-    const statusBar = document.querySelector('meta[name="theme-color"]');
-    if (statusBar) {
-      statusBar.setAttribute('content', '#101828');
-    }
-    return () => {
-      if (statusBar) {
-        statusBar.setAttribute('content', '#FFFFFF');
-      }
-    };
-  }, []);
-
   const handleClick = () => {
     // TODO: Need GTM Migration
     // mp?.track(EVENT.OPEN_KAKAO_TALK.NAME, {
@@ -28,7 +14,7 @@ const BackgroundHeader = () => {
   };
 
   return (
-    <div className="fixed top-0 z-0 h-full w-full max-w-screen-layout-max bg-gray-900">
+    <div className="fixed top-[0.5px] z-0 h-full w-full max-w-screen-layout-max bg-gray-900">
       <header className="flex h-[56px] w-full items-center justify-between px-5 py-3">
         <div className="flex items-center gap-2">
           <RoundedLogo />

--- a/apps/web/src/app/(home)/components/(home)/HomeHeader.tsx
+++ b/apps/web/src/app/(home)/components/(home)/HomeHeader.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { useEffect } from 'react';
-
 import SearchLinkButton from '@/components/SearchLinkButton';
 import useScrollPosition from '@/hooks/useScrollPosition';
 import { cn } from '@/lib/cn';
@@ -11,16 +9,28 @@ import LogoLink from '../../../../components/common/Logo/LogiLink';
 const HomeHeader = () => {
   const isScrolled = useScrollPosition(90);
 
-  useEffect(() => {
-    const statusBar = document.querySelector('meta[name="theme-color"]');
-    if (statusBar) {
-      if (isScrolled) {
-        statusBar.setAttribute('content', '#FFFFFF');
-      } else {
-        statusBar.setAttribute('content', '#101828');
-      }
-    }
-  }, [isScrolled]);
+  // useEffect(() => {
+  //   const statusBar = document.querySelector('meta[name="theme-color"]');
+  //   if (statusBar) {
+  //     statusBar.setAttribute('content', '#101828');
+  //   }
+  //   return () => {
+  //     if (statusBar) {
+  //       statusBar.setAttribute('content', '#FFFFFF');
+  //     }
+  //   };
+  // }, []);
+
+  // useEffect(() => {
+  //   const statusBar = document.querySelector('meta[name="theme-color"]');
+  //   if (statusBar) {
+  //     if (isScrolled) {
+  //       statusBar.setAttribute('content', '#FFFFFF');
+  //     } else {
+  //       statusBar.setAttribute('content', '#101828');
+  //     }
+  //   }
+  // }, [isScrolled]);
 
   const handleSearchClick = () => {
     // TODO: Need GTM Migration

--- a/apps/web/src/app/(home)/components/(home)/JirumRankingContainer.tsx
+++ b/apps/web/src/app/(home)/components/(home)/JirumRankingContainer.tsx
@@ -18,10 +18,10 @@ const JirumRankingContainer = () => {
       <ApiErrorBoundary>
         <Suspense
           fallback={
-            <>
+            <div className="mt-2">
               <JirumRankingSliderSkeleton />
               <SliderDotsSkeleton total={10} />
-            </>
+            </div>
           }
         >
           <JirumRankingSlider />
@@ -98,7 +98,7 @@ const SliderDotsSkeleton = ({ total }: { total: number }) => (
 export const JirumRankingSliderSkeleton = () => {
   return (
     <>
-      <div className="relative mt-2 flex animate-pulse justify-center overflow-x-hidden pb-3">
+      <div className="relative flex animate-pulse justify-center overflow-x-hidden pb-2">
         <div className="flex h-[340px] w-auto justify-center">
           <div className="h-[340px] min-w-fit flex-shrink-0 origin-center scale-90 animate-pulse overflow-hidden rounded-lg bg-white shadow-[0_2px_12px_rgba(0,0,0,0.08)] transition-all">
             <div className="relative h-[240px] w-full">


### PR DESCRIPTION
<!-- 모든 섹션은 꼭 다 채우지 않아도 됩니다! -->

## 구현한 것

- 사파리 상태바 동작이 들쑥날쑥이라 하얗게 고정하는 PR입니다.
- iOS는 상태바와 접해있는 영역의 색상을 찾아서 상태바를 칠하는 것으로 보이는데,
- PWA로 만들어서 테스트 해보니 theme-color 메타태그를 동적으로 변경시켜주면 거기에 따라서 상태바도 잘 칠해집니다.
- 근데.. 사파리에서는 다른 페이지(하얀 상태바)로 최초진입한 후에 홈으로 가면 잘 동작하지만 처음부터 홈으로 들어가면 상태바 색상이 어둡게 고정돼버립니다..
- 따라서 지난 회의에서 나온 의견대로 하얗게 고정하도록 하겠습니다.

- 랭킹슬라이더 스켈레톤 UI 위치가 조금 이상해서 수정했습니다.

## 구현하지 않은 것

<!-- PR에서 구현하지 않아 확인하지 않아도 되는 것을 적어주세요 -->

## 동작 확인

![image](https://github.com/user-attachments/assets/396b957d-63dc-4150-b7e7-95b58c30df6c)
