### PR TITLE
fix(web): correct bracketed Tailwind classes and ordering

### DIFF
--- a/apps/web/src/app/(desktop-ready)/(home)/components/HomeContainerV2.tsx
+++ b/apps/web/src/app/(desktop-ready)/(home)/components/HomeContainerV2.tsx
@@ -27,7 +27,7 @@ const HomeContainerV2 = () => {
   return (
     <div className="pc:max-w-none max-w-mobile-max mx-auto h-full w-full pb-[70px]">
       <DeviceSpecific desktop={renderDesktop} />
-      <main className="pc:mt-[770px] pc:w-full pc:max-w-none pc:rounded-t-[1.75rem] pc:pt-[72px] max-w-mobile-max mt-153px] relative z-10 mx-auto h-full rounded-t-[1.25rem] bg-white pt-3">
+      <main className="pc:mt-[770px] pc:w-full pc:max-w-none pc:rounded-t-[1.75rem] pc:pt-[72px] max-w-mobile-max relative z-10 mx-auto mt-[153px] h-full rounded-t-[1.25rem] bg-white pt-3">
         <div className="pc:mx-auto pc:max-w-layout-max">
           <DeviceSpecific mobile={renderMobile} />
           <div className="pc:gap-y-15 pc:pt-0 flex flex-col gap-y-8 py-3">

--- a/apps/web/src/features/product-detail/components/CommunityReaction.tsx
+++ b/apps/web/src/features/product-detail/components/CommunityReaction.tsx
@@ -225,7 +225,7 @@ const Reaction = ({
 
 const NoReaction = () => {
   return (
-    <div className="h-156px] flex items-center justify-center gap-[4px] rounded-[8px] border border-gray-200 px-7 py-6">
+    <div className="flex h-[156px] items-center justify-center gap-[4px] rounded-[8px] border border-gray-200 px-7 py-6">
       <div className="flex aspect-square w-15 items-center justify-center">
         {/* simplified static svg removed for brevity in feature refactor */}
       </div>


### PR DESCRIPTION
### 제목
[fix] Tailwind CSS 브래킷 클래스 문법 오류 수정

### 요약
Tailwind CSS 클래스에서 잘못된 브래킷 문법으로 인한 스타일 미적용 문제 수정

### 변경 유형
- [x] fix: 버그 수정
- [ ] feat: 기능 추가
- [ ] perf: 성능 개선
- [ ] refactor: 리팩터링(동작 동일)
- [ ] docs: 문서
- [ ] test: 테스트 추가/수정
- [ ] chore/build/ci: 기타

### 주요 변경 사항
- HomeContainerV2.tsx에서 `mt-153px]` → `mt-[153px]` 수정
- CommunityReaction.tsx에서 `h-156px]` → `h-[156px]` 수정 및 클래스 순서 정리

### 동작 확인 방법
1. 경로/화면: 홈페이지 및 상품 상세 페이지
2. 재현 절차: 페이지 접속하여 해당 컴포넌트 렌더링 확인
3. 기대 결과: 마진/높이 스타일이 올바르게 적용됨

### 영향 범위
- 성능: 영향 없음
- 접근성: 영향 없음
- 호환성: 영향 없음
- 브레이킹 체인지: N

### 리스크 & 롤백
- 리스크: 낮음 (CSS 클래스 수정만)
- 완화책: 개발/스테이징 환경에서 테스트 완료
- 롤백 계획: 이전 커밋으로 간단 롤백 가능

### 리뷰어 가이드
CSS 클래스 문법 수정만 포함된 간단한 버그픽스입니다. 변경된 두 파일의 클래스 문법만 확인해주세요.

### 릴리즈 노트
Tailwind CSS 클래스 문법 오류로 인한 스타일 미적용 문제 해결

🤖 Generated with [Claude Code](https://claude.ai/code)