### PR TITLE
fix: 하이드레이션 경고 개선 및 suppressHydrationWarning 추가

### DIFF
--- a/apps/web/src/app/(desktop-ready)/products/[id]/components/desktop/ViewerCount.tsx
+++ b/apps/web/src/app/(desktop-ready)/products/[id]/components/desktop/ViewerCount.tsx
@@ -3,7 +3,7 @@ export default function ViewerCount({ count }: { count: number }) {
     <div className="bg-secondary-50 flex h-[48px] w-full items-center justify-center whitespace-nowrap">
       <span className="text-sm text-gray-700">
         지금&nbsp;
-        <strong className="text-secondary-500 font-semibold">
+        <strong className="text-secondary-500 font-semibold" suppressHydrationWarning>
           {count.toLocaleString('ko-kr')}명
         </strong>
         이 보고 있어요

--- a/apps/web/src/app/(desktop-ready)/products/[id]/components/mobile/ViewerCount.tsx
+++ b/apps/web/src/app/(desktop-ready)/products/[id]/components/mobile/ViewerCount.tsx
@@ -61,7 +61,7 @@ export default function ViewerCount({ productId }: ViewerCountProps) {
             >
               <span className="text-sm text-gray-700">
                 지금&nbsp;
-                <strong className="text-secondary-500 font-semibold">
+                <strong className="text-secondary-500 font-semibold" suppressHydrationWarning>
                   {count.toLocaleString('ko-kr')}명
                 </strong>
                 이 보고 있어요

--- a/apps/web/src/shared/ui/DisplayTime.tsx
+++ b/apps/web/src/shared/ui/DisplayTime.tsx
@@ -1,10 +1,7 @@
 'use client';
 
-import { useIsHydrated } from '@/hooks/useIsHydrated';
 import { displayTime } from '@/util/displayTime';
 
 export default function DisplayTime({ time }: { time: Date }) {
-  const isHydrated = useIsHydrated();
-
-  return <span suppressHydrationWarning>{isHydrated ? displayTime(time) : ''}</span>;
+  return <span suppressHydrationWarning>{displayTime(time)}</span>;
 }


### PR DESCRIPTION
### 제목
[fix] 하이드레이션 경고 개선 및 suppressHydrationWarning 추가

### 요약
하이드레이션 경고를 해결하기 위해 서버-클라이언트 렌더링 불일치가 발생하는 동적 데이터 표시 부분에 suppressHydrationWarning 속성을 추가했습니다.

### 변경 유형
- [x] fix: 버그 수정
- [ ] feat: 기능 추가
- [ ] perf: 성능 개선
- [ ] refactor: 리팩터링(동작 동일)
- [ ] docs: 문서
- [ ] test: 테스트 추가/수정
- [ ] chore/build/ci: 기타

### 주요 변경 사항
- ViewerCount 컴포넌트(데스크톱/모바일)의 동적 숫자 표시 부분에 suppressHydrationWarning 추가
- DisplayTime 컴포넌트에서 불필요한 useIsHydrated 훅 제거 및 suppressHydrationWarning 적용
- DisplayPrice 컴포넌트 개선 (스테이징된 변경사항)

### 동작 확인 방법
1. 경로/화면: `/products/[id]` 상품 상세 페이지
2. 재현 절차: 상품 페이지 접속 → 개발자 도구 콘솔 확인
3. 기대 결과: 하이드레이션 경고 메시지가 표시되지 않음

### 영향 범위
- 성능: 하이드레이션 경고로 인한 불필요한 경고 메시지 제거
- 접근성: 변경 없음
- 호환성: 기존 기능 유지
- 브레이킹 체인지: 없음

### 리스크 & 롤백
- 리스크: suppressHydrationWarning 사용으로 실제 하이드레이션 문제 감추기 가능성
- 완화책: 동적 데이터가 예상되는 부분에만 제한적으로 적용
- 롤백 계획: suppressHydrationWarning 속성 제거로 즉시 롤백 가능

### 관련 이슈/문서
- 하이드레이션 경고 개선 작업

### 리뷰어 가이드
- ViewerCount, DisplayTime, DisplayPrice 컴포넌트의 suppressHydrationWarning 사용이 적절한지 확인
- 실제 하이드레이션 문제가 해결되었는지 브라우저에서 테스트

### 릴리즈 노트
하이드레이션 경고 메시지가 개선되어 콘솔 로그가 더 깔끔해집니다.