### PR TITLE
ci(admin): deploy via kustomize overlay newTag

### DIFF
--- a/.github/workflows/deploy-admin-prod.yml
+++ b/.github/workflows/deploy-admin-prod.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Use Node.js
         uses: actions/setup-node@v4
@@ -72,7 +72,7 @@ jobs:
           IMAGE_TAG: ${{ steps.image.outputs.version }}
 
       - name: Checkout kubernetes infra repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ env.INFRA_GITHUB_REPOSITORY }}
           ref: main
@@ -89,21 +89,17 @@ jobs:
 
       - name: Update Kubernetes manifest
         working-directory: infra
+        env:
+          NEW_TAG: ${{ steps.image.outputs.version }}
         run: |
           set -euo pipefail
-          DEPLOYMENT_FILE="server/jirum-alarm-frontend-admin/production/$INFRA_GITHUB_REPOSITORY_DEPLOY_FILE_PATH"
-
-          # Build image url
-          export IMAGE_URL="harbor.kyojs.com/tjsry0466/jirum-alarm-admin:${{ steps.image.outputs.version }}"
-          yq eval -i '.spec.template.spec.containers[0].image = strenv(IMAGE_URL)' "$DEPLOYMENT_FILE"
-
-          # Change cause
-          export CHANGE_CAUSE="Deployed by GitHub Actions - ${{ github.sha }}"
-          yq eval -i '.spec.template.metadata.annotations."kubernetes.io/change-cause" = strenv(CHANGE_CAUSE)' "$DEPLOYMENT_FILE"
-
-          # Timestamp to trigger rollout
-          export TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-          yq eval -i '.spec.template.metadata.annotations."deployment.kubernetes.io/revision-timestamp" = strenv(TIMESTAMP)' "$DEPLOYMENT_FILE"
+          # kustomize overlay 의 images[].newTag 한 곳만 갱신한다.
+          # (이전: server/.../deployment.yaml 의 image 라인 직접 치환 — 더는 ArgoCD 가 보지 않는 경로)
+          # version = github.sha[0:8] 이라 매 배포마다 값이 달라져 ArgoCD 가 자연 rollout (어노테이션 트릭 불필요).
+          KUSTOMIZATION="apps/frontend-admin/overlays/production/kustomization.yaml"
+          IMAGE_NAME="harbor.kyojs.com/tjsry0466/jirum-alarm-admin"
+          export IMAGE_NAME NEW_TAG
+          yq eval -i '(.images[] | select(.name == strenv(IMAGE_NAME)) | .newTag) = strenv(NEW_TAG)' "$KUSTOMIZATION"
 
       - name: Commit files
         working-directory: infra


### PR DESCRIPTION
## 배경

infra repo의 frontend-admin 매니페스트가 kustomize 구조(`apps/frontend-admin/overlays/production`)로 전환되었고, ArgoCD Application(`jirum-alarm-admin`)의 `source.path`도 이미 새 경로를 가리킵니다(Synced/Healthy).

→ 배포 워크플로가 갱신하던 `server/.../deployment.yaml`은 더 이상 ArgoCD가 보지 않으므로, 이 PR이 워크플로를 새 경로에 맞춥니다. (web PR #311과 동일 패턴)

## 변경 (`deploy-admin-prod.yml`)

| | AS-IS | TO-BE |
|---|---|---|
| 갱신 대상 | `server/jirum-alarm-frontend-admin/production/...-deployment.yaml` image 라인 | `apps/frontend-admin/overlays/production/kustomization.yaml` 의 `images[].newTag` |
| rollout 트리거 | `change-cause`/`revision-timestamp` 어노테이션 주입 | newTag 변경(version=`github.sha[0:8]`, 매 배포 변함)으로 자연 발생 |
| checkout | `@v4` (2곳) | `@v6` |

admin은 prod 단일 환경입니다 (`development/`는 dead — 대응 Application/워크로드 없음). staging 워크플로는 손대지 않았습니다.

## 검증

- `yq` newTag 치환 → `kustomize build` image 정확 반영 확인 (`...jirum-alarm-admin:<tag>`)
- YAML 문법 + step 순서 검증 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)