### PR TITLE
fix(mobile): iOS WebView 광고 iframe이 모달 인앱 브라우저 띄우는 문제 수정

### DIFF
--- a/apps/mobile/src/screens/jirumalarmwebview/hooks/useCommonWebViewLogic.ts
+++ b/apps/mobile/src/screens/jirumalarmwebview/hooks/useCommonWebViewLogic.ts
@@ -123,6 +123,14 @@ export function useCommonWebViewLogic() {
         return true;
       }
 
+      // iOS는 메인 프레임뿐 아니라 iframe/서브리소스 로드에도 이 핸들러가 실행된다.
+      // AdSense 광고 iframe(googlesyndication·doubleclick 등)이 매번 화이트리스트에
+      // 안 걸려 openInAppBrowser를 트리거하면 탭 이동마다 모달 브라우저가 떴다.
+      // 메인 프레임이 아닌 로드는 WebView가 그대로 처리하도록 통과시킨다.
+      if (event.isTopFrame === false) {
+        return true;
+      }
+
       if (
         !event.url.includes('jirum-alarm') &&
         !event.url.startsWith(SERVICE_URL)


### PR DESCRIPTION
## 문제

AdSense 연동 이후 **iOS 앱에서 탭을 누를 때마다 모달 인앱 브라우저가 뜨는** 버그.

## 원인

`onShouldStartLoadWithRequest`는 iOS에서 메인 프레임 클릭뿐 아니라 **모든 iframe·서브리소스·리다이렉트 로드마다 실행**된다. 외부 URL 화이트리스트(`jirum-alarm`/`SERVICE_URL`)에 안 걸리면 `openInAppBrowser`를 호출하는 로직이 있는데, AdSense 광고 iframe(`googlesyndication`·`doubleclick` 등)이 새 페이지마다 로드되며 매번 이 분기에 걸려 모달 브라우저를 띄웠다.

## 수정

`event.isTopFrame === false`(메인 프레임이 아닌 로드 = iframe·서브리소스)면 그대로 `return true`로 통과시켜 WebView가 처리하게 둔다. 실제 사용자가 외부 링크로 이동하는 top-frame 네비게이션에서만 인앱 브라우저를 연다.

- `isTopFrame`은 react-native-webview `ShouldStartLoadRequest`의 정식 boolean 필드
- Android는 원래 클릭 시에만 핸들러가 호출되므로 사실상 no-op (안전)
- `tsc --noEmit` 통과

## 검증 필요 (심사 빌드 후)

- [ ] iOS 실기기에서 탭 이동 시 모달 브라우저 안 뜨는지
- [ ] 외부 링크(about-us, 쇼핑몰 등)는 여전히 인앱 브라우저로 열리는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)